### PR TITLE
Fix bigint sort overflow in meme comparators

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -334,9 +334,9 @@ const Home: NextPage = () => {
     });
     switch (sortMode) {
       case "top":
-        return memes.sort((a, b) => Number(b.totalVotes - a.totalVotes));
+        return memes.sort((a, b) => (b.totalVotes > a.totalVotes ? 1 : b.totalVotes < a.totalVotes ? -1 : 0));
       case "new":
-        return memes.sort((a, b) => Number(b.submittedAt - a.submittedAt));
+        return memes.sort((a, b) => (b.submittedAt > a.submittedAt ? 1 : b.submittedAt < a.submittedAt ? -1 : 0));
       default:
         return memes;
     }
@@ -761,7 +761,7 @@ const Home: NextPage = () => {
             {/* Meme list for selection */}
             <div className="space-y-2 mb-4 max-h-[300px] overflow-y-auto">
               {[...(allMemes || [])]
-                .sort((a: any, b: any) => Number(b.totalVotes - a.totalVotes))
+                .sort((a: any, b: any) => (b.totalVotes > a.totalVotes ? 1 : b.totalVotes < a.totalVotes ? -1 : 0))
                 .map((meme: any) => {
                   const isSelected = selectedWinners.includes(Number(meme.id));
                   return (


### PR DESCRIPTION
## Problem

The sort comparators use `Number(b.totalVotes - a.totalVotes)` which can overflow `Number.MAX_SAFE_INTEGER` since CLAWD has 18 decimals. This could produce incorrect sort ordering.

## Fix

Use direct bigint comparison operators (`>`, `<`) instead of converting to Number. Fixed in 3 places:
- TOP sort (main grid)
- NEW sort (main grid)
- Admin judge modal sort