### PR TITLE
Add vote percentage label to pink bars

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -140,6 +140,7 @@ function MemeCard({
   meme,
   rank,
   maxVotes,
+  totalVotePool,
   isActive,
   isConnected,
   onBuy,
@@ -148,6 +149,7 @@ function MemeCard({
   meme: Meme;
   rank: number;
   maxVotes: bigint;
+  totalVotePool: bigint;
   isActive: boolean;
   isConnected: boolean;
   onBuy: (id: number) => void;
@@ -191,8 +193,13 @@ function MemeCard({
       </div>
 
       {/* Vote bar */}
-      <div className="h-1 bg-white/5">
+      <div className="relative h-5 bg-white/5">
         <div className="h-full vote-bar" style={{ width: `${Math.max(pct, 1)}%` }} />
+        {totalVotePool > 0n && (
+          <span className="absolute inset-0 flex items-center justify-center text-[9px] font-mono font-bold text-white/70">
+            {Number((meme.totalVotes * 100n) / totalVotePool)}% of votes
+          </span>
+        )}
       </div>
 
       {/* Info + action strip */}
@@ -345,6 +352,11 @@ const Home: NextPage = () => {
   const maxVotes = useMemo(() => {
     if (!allMemes || allMemes.length === 0) return 0n;
     return [...allMemes].reduce((max, m) => (m.totalVotes > max ? m.totalVotes : max), 0n);
+  }, [allMemes]);
+
+  const totalVotePool = useMemo(() => {
+    if (!allMemes || allMemes.length === 0) return 0n;
+    return [...allMemes].reduce((sum, m) => sum + m.totalVotes, 0n);
   }, [allMemes]);
 
   /* ═══ Countdown ═══ */
@@ -587,6 +599,7 @@ const Home: NextPage = () => {
                 meme={meme as Meme}
                 rank={rank}
                 maxVotes={maxVotes}
+                totalVotePool={totalVotePool}
                 isActive={isActive && !isEnded}
                 isConnected={isConnected}
                 onBuy={handleBuy}


### PR DESCRIPTION
## Before
Thin pink bars with no context — unclear what they represent.

## After
Bars now display "X% of votes" centered on them. Percentage = share of total vote pool across all memes.

- Bar height: h-1 → h-5 for readability
- Bar width: still relative to top meme (visual comparison)
- Label: centered white text showing pool share percentage